### PR TITLE
fix docker run

### DIFF
--- a/docs/lab-01/README.md
+++ b/docs/lab-01/README.md
@@ -15,7 +15,7 @@ Run Ubuntu docker image and mount the directory there:
 
 ```bash
 mkdir /tmp/test && cd /tmp/test
-docker run -it -rm -v $PWD:/mnt ubuntu
+docker run -it --rm -v $PWD:/mnt ubuntu
 ```
 
 Install necessary software into the Docker container:


### PR DESCRIPTION
```
rmelero-mbp:test rmelero$ docker run -it -rm -v $PWD:/mnt ubuntu
unknown shorthand flag: 'r' in -rm
See 'docker run --help'.
```
```
      --rm                             Automatically remove the container when it exits
```